### PR TITLE
update settings to strike confusing settings

### DIFF
--- a/afs_demo/settings.py
+++ b/afs_demo/settings.py
@@ -144,8 +144,6 @@ DATABASES = {
     }
 }
 
-SEARCH_THUMBNAILS = False
-
 INSTALLED_APPS = (
     "webpack_loader",
     "django.contrib.admin",


### PR DESCRIPTION
SEARCH_THUMBNAILS is set twice - this purges the first (and overridden) setting.